### PR TITLE
Cards resized.

### DIFF
--- a/client/projectDataRetriever.js
+++ b/client/projectDataRetriever.js
@@ -42,7 +42,7 @@ class Projects extends React.Component<Props, void> {
         <img
           src={card.image[0]}
           alt={card.image[1]}
-          style={{ height: 137 }}
+          style={{ height: card.image[2] }}
         />
       </CardMedia>
     ) : ''
@@ -65,7 +65,7 @@ class Projects extends React.Component<Props, void> {
     // Return a card.
     return (
       <Grid item xs>
-        <Card raised style={{ height: 360 }}>
+        <Card raised style={{ height: 330 }}>
           {card.image ? <br /> : ''}
           {card.image ? <Image /> : ''}
           <CardContent>


### PR DESCRIPTION
So I resized the cards again, because they didn't look pretty good with bigger images fixed on 127px height.
Compare: (resized in this PR)
![image](https://user-images.githubusercontent.com/12954909/31298383-975d1236-aaf2-11e7-83dc-9e28f53a2d23.png)
with this: (before)
![image](https://user-images.githubusercontent.com/12954909/31298412-b3f41dc2-aaf2-11e7-80fb-9e349b619007.png)

Also you told the release will be on 14th. I'll be on math competition on 14th. But hopefully this won't change the plan and the October release will be deployed.
And please add Slack icon next to the Github icon.
If there are problems chat in Slack.